### PR TITLE
changed `tabler-icons` package to `@tabler/icons`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "build": "node ./scripts/generate.js"
     },
     "devDependencies": {
-        "tabler-icons": "^1.34.0"
+        "@tabler/icons": "^1.35.0"
     },
     "files": [
         "dist",


### PR DESCRIPTION
Hi! We moved `tabler-icons` package to `@tabler` scope in npm. Old package will be deprecated soon. 

Thank you for your work! :) 