### PR TITLE
add `"type": "module"` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "type": "git",
         "url": "https://github.com/benflap/tabler-icons-svelte.git"
     },
+    "type": "module",
     "svelte": "index.js",
     "main": "index.js",
     "types": "index.d.ts",


### PR DESCRIPTION
The `main` is ESM, so you need `"type": "module"`. The latest version of Vite is complaining that it's missing