### PR TITLE
Support passing down of `class` prop

### DIFF
--- a/scripts/component-template.svelte
+++ b/scripts/component-template.svelte
@@ -2,11 +2,14 @@
     export let size = 24;
     export let color = "currentColor";
     export let strokeWidth = 2;
+
+    let clazz = '';
+    export { clazz as class }
 </script>
 
 <svg
     xmlns='http://www.w3.org/2000/svg'
-    class='icon icon-tabler icon-tabler-%%ORIGINAL_NAME%%'
+    class='icon icon-tabler icon-tabler-%%ORIGINAL_NAME%% {clazz}'
     width={size}
     height={size}
     viewBox='0 0 24 24'


### PR DESCRIPTION
Support passing down off class prop for usage with libraries like [TailwindCSS](https://tailwindcss.com/)

[Example in REPL](https://svelte.dev/repl/1d0b80898137445da24cf565830ce3f7?version=3.4.2)