### PR TITLE
Export Icon{name} in addition to bare {name}

### DIFF
--- a/scripts/generate.cjs
+++ b/scripts/generate.cjs
@@ -102,7 +102,7 @@ async function createIndexFile() {
         const [originalName] = file.split(".");
         const componentName = createComponentName(originalName);
 
-        return `export { default as ${componentName} } from "./icons/${componentName}.svelte"`;
+        return `export { default as ${componentName}, default as Icon${componentName} } from "./icons/${componentName}.svelte"`;
     });
 
     fs.writeFileSync(


### PR DESCRIPTION
Hey, first of all thanks for your wonderful project!

I propose exporting icons as `Icon{name}` in the index file. This has the following advantages:

- If an icon name conflicts with another component (e. g. `ShoppingCart` could refer to a shopping cart widget already), user can just import `IconShoppingCart` instead (and they can just always import Icon-prefixed variants if desired)

- Users will also be able to copy component name directly from https://tabler-icons.io/ (except for `Icon2fa` and `Icon3d*` – we can do those too, but it would require deeper changes to `createIndexFile()`)

Versions without a prefix should work as well.