### PR TITLE
Support Svelte 3.31 -> 5@next

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "prettier-plugin-svelte": "^2.9.0"
     },
     "peerDependencies": {
-        "svelte": ">=3.31.0 <=4"
+        "svelte": "^3.31.0 || ^4.0.0 || ^5.0.0-next.0"
     },
     "files": [
         "icons",


### PR DESCRIPTION
I want to use Tabler in an internal Svelte 5 project but Tabler fails to build. Added a version range that supports 3.31 -> 5@next so any valid released version of Svelte can work with Tabler

Format of deps matches that of the [`@sveltejs/kit`](https://github.com/sveltejs/kit/blob/main/packages/kit/package.json#L44) project for consistency